### PR TITLE
add api endpoint for getting list of current mirrors

### DIFF
--- a/app/controllers/mod.py
+++ b/app/controllers/mod.py
@@ -867,6 +867,11 @@ def fetch_checksums():
     return jsonify(result=result)
 
 
+@app.route('/api/1/repo/mirrors', methods={'GET'})
+def get_dl_mirrors():
+    return jsonify(result=app.config['DL_MIRRORS'])
+
+
 def render_mod_list(mods, private=False, no_chksum=False):
     repo = []
     files = {}


### PR DESCRIPTION
Not super useful, but prevents having to hard code the list of mirrors for repo.json and other non-mod files.