### PR TITLE
decouple repo.json generation from main app

### DIFF
--- a/app/controllers/mod.py
+++ b/app/controllers/mod.py
@@ -1117,9 +1117,8 @@ def render_mod_list_minimal(mods):
 
 
 def generate_repo():
-    repo_path = os.path.join(app.config['FILE_STORAGE'], 'public', 'repo.json')
     repo_min_path = os.path.join(app.config['FILE_STORAGE'], 'public', 'repo_minimal.json')
-    lock_path = repo_path + '.lock'
+    lock_path = repo_min_path + '.lock'
 
     if os.path.isfile(lock_path):
         app.logger.error('Skipping repo update because another update is already in progress!')
@@ -1133,12 +1132,6 @@ def generate_repo():
 
         mods = Mod.objects.exclude(*exclude_fields).select_related(4)
 
-        # full repo list
-        repo = render_mod_list(mods)
-
-        with open(repo_path, 'w') as stream:
-            json.dump({'mods': repo}, stream) # , seperator=(',',':'))
-
         # minimal repo list
         repo = render_mod_list_minimal(mods)
 
@@ -1147,6 +1140,10 @@ def generate_repo():
 
     except Exception:
         app.logger.exception('Failed to update repository data!')
+
+    # flag big repo as needing an update
+    update_required = os.path.join(app.config['FILE_STORAGE'], 'repo_needs_update')
+    open(update_required, 'w').close()
 
     app.logger.info('Repo update finished.')
     os.unlink(lock_path)

--- a/gen_repo.py
+++ b/gen_repo.py
@@ -1,0 +1,36 @@
+import os.path
+import json
+from app import app
+from app.models import Mod
+from app.controllers.mod import render_mod_list
+
+update_required = os.path.join(app.config['FILE_STORAGE'], 'repo_needs_update')
+repo_path = os.path.join(app.config['FILE_STORAGE'], 'public', 'repo.json')
+lock_path = repo_path + '.lock'
+
+if os.path.isfile(lock_path):
+    print('Update already in progress!')
+    exit(0)
+
+# if we don't need an update then bail
+if not os.path.isfile(update_required):
+    exit(0)
+
+open(lock_path, 'w').close()
+print('Updating repo...')
+
+try:
+    exclude_fields = ('members', 'team', 'releases')
+
+    mods = Mod.objects.exclude(*exclude_fields).select_related(4)
+    repo = render_mod_list(mods)
+
+    with open(repo_path, 'w') as stream:
+        json.dump({'mods': repo}, stream) # , seperator=(',',':'))
+except Exception:
+    print('Failed to update repository data!')
+else:
+    print('Repo update complete.')
+
+os.unlink(lock_path)
+os.unlink(update_required)

--- a/update_repo_json.sh.sample
+++ b/update_repo_json.sh.sample
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+export NEBULA_SETTINGS=./dev.cfg
+
+source ./.venv/bin/activate
+
+exec python ./gen_repo.py


### PR DESCRIPTION
This splits the resource intensive repo json generation into a separate script which can be executed by a cron job or other task. This prevents the main app/api from becoming unresponsive and timing out during repo generation.

The minimal json is still generated immediately as it takes 1-2 seconds to complete.

This only affects public mods. Repo generation for private mods is unchanged.