### PR TITLE
Fix stale private repo cache when mod switches from private to public

### DIFF
--- a/app/controllers/mod.py
+++ b/app/controllers/mod.py
@@ -418,6 +418,7 @@ def create_release():
         if release.private:
             generate_private_repo(mod)
         else:
+            clear_private_repo_cache(mod)
             generate_repo()
 
     if not release.private and not release.hidden and not (mod.mid == 'FSO' and release.stability == 'nightly'):
@@ -472,6 +473,7 @@ def update_release():
     if release.private:
         generate_private_repo(mod)
     else:
+        clear_private_repo_cache(mod)
         generate_repo()
 
         if old_rel.private and not release.hidden:
@@ -510,6 +512,7 @@ def delete_release():
     if release.private:
         generate_private_repo(mod)
     else:
+        clear_private_repo_cache(mod)
         generate_repo()
 
     return jsonify(result=True)
@@ -1148,6 +1151,13 @@ def generate_repo():
 
     app.logger.info('Repo update finished.')
     os.unlink(lock_path)
+
+
+def clear_private_repo_cache(mod):
+    for pattern in ('mod_%s.json', 'mod2_%s.json'):
+        path = os.path.join(app.config['FILE_STORAGE'], 'cache', pattern % mod.id)
+        if os.path.isfile(path):
+            os.unlink(path)
 
 
 def generate_private_repo(mod):


### PR DESCRIPTION
When a release changed from private to public, the per-mod cache files (mod_{id}.json, mod2_{id}.json) were never deleted. This caused the private repo endpoints to continue serving stale cached data, making mods inaccessible to users with tester permissions.

Fixes KnossosNET/Knossos.NET#261