### PR TITLE
Fix broken private_repo_v2 endpoint: malformed JSON and undefined variable

### DIFF
--- a/app/controllers/mod.py
+++ b/app/controllers/mod.py
@@ -873,7 +873,7 @@ def private_repo_v2():
                 if content != '':
                     repo.append(content)
 
-    return '{"result:true,"mods":[%s]}' % ','.join(rels)
+    return '{"result":true,"mods":[%s]}' % ','.join(repo)
 
 
 @app.route('/api/1/repo/checksums', methods={'POST'})


### PR DESCRIPTION
The response string had a missing quote ("result:true" → "result":true) and referenced an undefined variable `rels` instead of `repo`, making the endpoint non-functional.