### PR TITLE
Make multiupload/finish idempotent to prevent cascade of 500 errors on retry

### DIFF
--- a/app/controllers/upload.py
+++ b/app/controllers/upload.py
@@ -144,6 +144,9 @@ def finish_chunked_upload():
     if not file:
         abort(404)
 
+    if file.done:
+        return jsonify(result=True)
+
     record = UploadedFile(expires=time.time() + 60 * 60,
                           checksum=request.form['checksum'],
                           content_checksum=request.form.get('content_checksum'),


### PR DESCRIPTION
When a client calls multiupload/finish and the reverse proxy times out (504) before the response reaches the client, the client retries. Each retry would create a duplicate UploadedFile record (causing NotUniqueError) or fail reading already-deleted chunks (FileNotFoundError), both surfacing as 500 errors. This was observed in production as 17 rapid-fire 500s.

Check file.done at the top of finish_chunked_upload and return success immediately if the upload was already finalized, avoiding redundant reassembly and the resulting errors.